### PR TITLE
Send extra ranks' output to devnull

### DIFF
--- a/example_chat_completion.py
+++ b/example_chat_completion.py
@@ -6,6 +6,13 @@ from typing import List, Optional
 import fire
 
 from llama import Llama, Dialog
+import sys, os
+
+def check_if_torchrun():
+    if "RANK" in os.environ:
+        return int(os.environ["RANK"])
+    else:
+        return -1 # not in torchrun
 
 
 def main(
@@ -32,6 +39,11 @@ def main(
         max_gen_len (int, optional): The maximum length of generated sequences. If None, it will be
             set to the model's max sequence length. Defaults to None.
     """
+
+    # send output to /dev/null if global rank is non-zero
+    if check_if_torchrun() > 0:
+        sys.stdout = open(os.devnull, "w")
+
     generator = Llama.build(
         ckpt_dir=ckpt_dir,
         tokenizer_path=tokenizer_path,

--- a/example_text_completion.py
+++ b/example_text_completion.py
@@ -5,6 +5,13 @@ import fire
 
 from llama import Llama
 from typing import List
+import sys, os
+
+def check_if_torchrun():
+    if "RANK" in os.environ:
+        return int(os.environ["RANK"])
+    else:
+        return -1
 
 def main(
     ckpt_dir: str,
@@ -29,6 +36,11 @@ def main(
         max_gen_len (int, optional): The maximum length of generated sequences. Defaults to 64.
         max_batch_size (int, optional): The maximum batch size for generating sequences. Defaults to 4.
     """ 
+    
+    # send output to /dev/null if global rank is non-zero
+    if check_if_torchrun() > 0:
+        sys.stdout = open(os.devnull, "w")
+        
     generator = Llama.build(
         ckpt_dir=ckpt_dir,
         tokenizer_path=tokenizer_path,


### PR DESCRIPTION
@jIskCoder 

This adds some code that sends the other nodes' output to /dev/null so only one output is printed to the terminal/slurm output file.